### PR TITLE
Add comment at CMakeLists for copy lib file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ elseif(MSVC)
 endif()
 
 # Create a custom target that copies both files after parser_static is built.
-add_custom_command(TARGET parser_static POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${PARSER_OBJ} ${CMAKE_SOURCE_DIR}/build/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PARSER_A} ${CMAKE_SOURCE_DIR}/build/
-    COMMENT "Copying parser.o and parser.a to the build directory"
-)
+# add_custom_command(TARGET parser_static POST_BUILD
+#     COMMAND ${CMAKE_COMMAND} -E copy ${PARSER_OBJ} ${CMAKE_SOURCE_DIR}/build/
+#     COMMAND ${CMAKE_COMMAND} -E copy ${PARSER_A} ${CMAKE_SOURCE_DIR}/build/
+#     COMMENT "Copying parser.o and parser.a to the build directory"
+# )


### PR DESCRIPTION
Either pip or cmake can build successfully without copy parser.o and parser.a